### PR TITLE
Translator Include

### DIFF
--- a/Translators/PHP_MySQL/include.edml
+++ b/Translators/PHP_MySQL/include.edml
@@ -1,0 +1,15 @@
+<participant name="transDynData1">
+  <translator priority=400>
+    <searchPatterns>
+      <searchPattern><![CDATA[include]]></searchPattern>
+      <searchPattern><![CDATA[$WEBSITE]]></searchPattern>
+      <searchPattern paramNames=",rs,col,file"><![CDATA[/include\s*(\w*\s*\(\s*)?\$WEBSITE\[["'](HOSTING)["']\]\[["'](ANGGOTA|ADMINISTRATOR|TEMPLATE)["']\]\s*.['](.*?)[']\)?;?/i]]></searchPattern>
+    </searchPatterns>
+    <translations>
+      <translation whereToSearch="directive" translationType="dynamic data">
+        <openTag>MM_DYNAMIC_CONTENT</openTag>
+        <display><![CDATA[<div align="center" style="clear:both;"><p>INCLUDE</p>[@@rs@@][@@col@@]<p>@@file@@</p></div>]]></display>
+        <closeTag>MM_DYNAMIC_CONTENT</closeTag>
+      </translation>
+  </translator>
+</participant>


### PR DESCRIPTION
Mengubah kode include php kedalam Desain Visual agar memudahkan dalam memahami file apa saja yang diinclude oleh sebuah pemroses/halaman aplikasi tanpa harus membuka kode program.